### PR TITLE
Update networkx dependency version to 3.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,6 @@ dev = [
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "ruff>=0.12.8",
-    "types-networkx>=3.4.2",
+    "types-networkx>=3.4.0.20240928",
     "types-tqdm>=4.67.0.20250809",
 ]


### PR DESCRIPTION
The current constraints cannot be satisfied for Python 3.10 because networkx>=3.5 requires Python 3.11. 

If you allow for networkx>=3.4.2, then Python 3.10 can be used too.

Ignore or close as you wish!